### PR TITLE
Stop propagation of some keys

### DIFF
--- a/plugin/src/components/annotation/CreateAnnotationModal.tsx
+++ b/plugin/src/components/annotation/CreateAnnotationModal.tsx
@@ -39,9 +39,18 @@ export default function CreateAnnotationModal({ range, ...props }: CreateAnnotat
 
   const form = useRef<HTMLFormElement | null>(null)
   const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useEvent((event) => {
-    if (event.key === 'Enter' && event.metaKey) {
-      event.preventDefault()
-      form.current!.submit()
+    if (event.key === 'Enter') {
+      event.stopPropagation()
+      if (event.metaKey) {
+        event.preventDefault()
+        form.current!.submit()
+      }
+    }
+  })
+
+  const onKeyPress: KeyboardEventHandler<HTMLTextAreaElement> = useEvent((event) => {
+    if (event.key === '?') {
+      event.stopPropagation()
     }
   })
 
@@ -66,6 +75,7 @@ export default function CreateAnnotationModal({ range, ...props }: CreateAnnotat
             {...register('comment', { required: true })}
             error={errors.comment?.message}
             onKeyDown={onKeyDown}
+            onKeyPress={onKeyPress}
           />
 
           <Button type="submit" loading={isSubmitting} className="w-full">

--- a/plugin/src/components/chat/MessageInput.tsx
+++ b/plugin/src/components/chat/MessageInput.tsx
@@ -42,11 +42,19 @@ export default forwardRef<HTMLTextAreaElement, MessageInputProps>(function Messa
     ...props,
   }
 
-  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useEvent((event) => {
-    if (event.key === 'Enter' && event.metaKey) {
-      event.preventDefault()
-      onSend?.()
+  const onKeyPress: KeyboardEventHandler<HTMLTextAreaElement> = useEvent((event) => {
+    if (event.key === '?') {
+      event.stopPropagation()
     }
+  })
+
+  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useEvent((event) => {
+    if (event.key === 'Enter') {
+      event.stopPropagation()
+      if (event.metaKey) {
+        event.preventDefault()
+        onSend?.()
+      }
   })
 
   const replyToMessage = replyTo ? truncate(replyTo.text, { length: 100 }) : undefined
@@ -86,6 +94,7 @@ export default forwardRef<HTMLTextAreaElement, MessageInputProps>(function Messa
         className="form-textarea overflow-y-auto block w-full py-2 border-0 resize-none focus:ring-0 text-sm"
         style={{ minHeight: '16px', maxHeight: '96px' }}
         onKeyDown={onKeyDown}
+        onKeyPress={onKeyPress}
         onChange={onChange}
       />
     </div>


### PR DESCRIPTION
For me, entering a "?" as part of an annotation or chat message opens the help screen.  Prevent this.

Also, I use the jump plugin, which jumps to a different slide after
pressing numbers and enter.   Prevent this.