### PR TITLE
Add hints what is required or optional

### DIFF
--- a/plugin/src/components/auth/LoginForm.tsx
+++ b/plugin/src/components/auth/LoginForm.tsx
@@ -38,7 +38,7 @@ export default function LoginForm({ onSubmit: onLogin }: LoginFormProps) {
 
   return (
     <form onSubmit={handleFormError(handleSubmit(onSubmit))} className="space-y-4">
-      <Input label="Email" type="email" {...register('email', { required: true })} error={errors.email?.message} />
+      <Input label="E-mail" type="email" {...register('email', { required: true })} error={errors.email?.message} />
       <Input
         label="Password"
         type="password"

--- a/plugin/src/components/auth/RegisterForm.tsx
+++ b/plugin/src/components/auth/RegisterForm.tsx
@@ -82,15 +82,15 @@ export default function RegisterForm({ onSubmit: onRegister }: RegisterFormProps
         </div>
 
         <div className="space-y-4 px-2 flex-1">
-          <Input label="Email" type="email" {...register('email', { required: true })} error={errors.email?.message} />
+          <Input label="E-mail (does not need to work, e.g., foo@example.org)" type="email" {...register('email', { required: true })} error={errors.email?.message} />
           <Input
-            label="Password"
+            label="Password (8-32 characters)"
             type="password"
             {...register('password', { required: true, minLength: 8, maxLength: 32 })}
             error={errors.password?.message}
           />
-          <Input label="Name" type="text" {...register('name', { required: true })} error={errors.name?.message} />
-          <Textarea label="Bio" rows={4} className="resize-none" {...register('bio')} />
+          <Input label="Name (required, maybe pseudonym)" type="text" {...register('name', { required: true })} error={errors.name?.message} />
+          <Textarea label="Bio (optional)" rows={4} className="resize-none" {...register('bio')} />
           <ColorPicker
             size="md"
             label="Profile color"


### PR DESCRIPTION
This adds hints what is required or optional for registration of accounts.

In my local setup I also added hardcoded links to privacy policy and imprint after the `span` in `SignInModal.tsx`:

```
<br />
(By signing up, you agree to the <span className="hover:cursor-pointer hover:underline-offset-1 hover:underline hover:text-gray-700"> <a href="/privacy.html">Privacy Policy</a></span>.  <span className="hover:cursor-pointer hover:underline-offset-1 hover:underline hover:text-gray-700"> <a href="/imprint.html">Imprint</a></span>)
```

Maybe something like that could be configurable? 